### PR TITLE
Refactor services to use defineProtectedProcedure and definePublicProcedure

### DIFF
--- a/api/src/services/account/accountActivate.ts
+++ b/api/src/services/account/accountActivate.ts
@@ -2,14 +2,14 @@ import { Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import logActivity from '../../util/activity.js'
 import { sendMail } from '../../util/mail.js'
 
-export const accountActivateProcedure = defineProcedure({
+export const accountActivateProcedure = defineProtectedProcedure({
   key: 'activate',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: z.strictObject({
     accountId: z.number().int(),
   }),

--- a/api/src/services/account/accountChangePassword.ts
+++ b/api/src/services/account/accountChangePassword.ts
@@ -3,16 +3,16 @@ import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import logActivity from '../../util/activity.js'
 
 import { hashPassword, passwordMatches } from '@codeanker/authentication'
 import { isStrongPassword } from '@codeanker/helpers'
 
-export const accountChangePasswordProcedure = defineProcedure({
+export const accountChangePasswordProcedure = defineProtectedProcedure({
   key: 'changePassword',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema: z.strictObject({
     id: z.number().int(),
     password_old: z.string(),

--- a/api/src/services/account/accountEmailConfirmRequest.ts
+++ b/api/src/services/account/accountEmailConfirmRequest.ts
@@ -2,15 +2,15 @@ import { Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import logActivity from '../../util/activity.js'
 
 import { sendMailConfirmEmailRequest } from './helpers/sendMailConfirmEmailRequest.js'
 
-export const accountEmailConfirmRequestProcedure = defineProcedure({
+export const accountEmailConfirmRequestProcedure = defineProtectedProcedure({
   key: 'emailConfirmRequest',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: z.strictObject({
     accountId: z.number().int(),
   }),

--- a/api/src/services/account/accountVerwaltungCreate.ts
+++ b/api/src/services/account/accountVerwaltungCreate.ts
@@ -2,15 +2,15 @@ import { Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 
 import { sendMailConfirmEmailRequest } from './helpers/sendMailConfirmEmailRequest.js'
 import { accountSchema, getAccountCreateData } from './schema/account.schema.js'
 
-export const accountVerwaltungCreateProcedure = defineProcedure({
+export const accountVerwaltungCreateProcedure = defineProtectedProcedure({
   key: 'verwaltungCreate',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: z.strictObject({
     data: accountSchema,
   }),

--- a/api/src/services/account/accountVerwaltungList.ts
+++ b/api/src/services/account/accountVerwaltungList.ts
@@ -2,7 +2,7 @@ import { Prisma, Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import { defineQuery, getOrderBy } from '../../types/defineQuery.js'
 
 const inputSchema = defineQuery({
@@ -20,10 +20,10 @@ const inputSchema = defineQuery({
   ),
 })
 
-export const accountVerwaltungListProcedure = defineProcedure({
+export const accountVerwaltungListProcedure = defineProtectedProcedure({
   key: 'verwaltungList',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema,
   async handler(options) {
     const { skip, take } = options.input.pagination
@@ -61,10 +61,10 @@ export const accountVerwaltungListProcedure = defineProcedure({
   },
 })
 
-export const accountVerwaltungCountProcedure = defineProcedure({
+export const accountVerwaltungCountProcedure = defineProtectedProcedure({
   key: 'verwaltungCount',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: inputSchema.pick({ filter: true }),
   async handler(options) {
     const list = await prisma.account.count({

--- a/api/src/services/account/accountVerwaltungRemove.ts
+++ b/api/src/services/account/accountVerwaltungRemove.ts
@@ -2,13 +2,13 @@ import { Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import logActivity from '../../util/activity.js'
 
-export const accountVerwaltungRemoveProcedure = defineProcedure({
+export const accountVerwaltungRemoveProcedure = defineProtectedProcedure({
   key: 'verwaltungRemove',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: z.strictObject({
     id: z.number().int(),
   }),

--- a/api/src/services/activity/activityList.ts
+++ b/api/src/services/activity/activityList.ts
@@ -2,7 +2,7 @@ import { type Prisma, Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import { defineQuery, getOrderBy } from '../../types/defineQuery.js'
 
 const inputSchema = defineQuery({
@@ -16,10 +16,10 @@ const inputSchema = defineQuery({
 
 type Input = z.infer<typeof inputSchema>
 
-export const activityListProcedure = defineProcedure({
+export const activityListProcedure = defineProtectedProcedure({
   key: 'list',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema,
   async handler({ input, ctx }) {
     const { skip, take } = input.pagination
@@ -47,10 +47,10 @@ export const activityListProcedure = defineProcedure({
   },
 })
 
-export const activityCountProcedure = defineProcedure({
+export const activityCountProcedure = defineProtectedProcedure({
   key: 'count',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: inputSchema.pick({ filter: true }),
   async handler({ input, ctx }) {
     const activities = await prisma.activity.count({

--- a/api/src/services/address/addressFindAddress.ts
+++ b/api/src/services/address/addressFindAddress.ts
@@ -2,12 +2,11 @@ import axios from 'axios'
 import z from 'zod'
 
 import config from '../../config.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { definePublicProcedure } from '../../types/defineProcedure.js'
 
-export const addressFindActionProcedure = defineProcedure({
+export const addressFindActionProcedure = definePublicProcedure({
   key: 'findAddress',
   method: 'query',
-  protection: { type: 'public' },
   inputSchema: z.object({
     query: z.string().optional(),
     zip: z.string().optional(),

--- a/api/src/services/anmeldung/anmeldungGliederungGet.ts
+++ b/api/src/services/anmeldung/anmeldungGliederungGet.ts
@@ -2,12 +2,12 @@ import { Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 
-export const anmeldungGliederungGetProcedure = defineProcedure({
+export const anmeldungGliederungGetProcedure = defineProtectedProcedure({
   key: 'gliederungGet',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema: z.strictObject({
     anmeldungId: z.number().optional(),
     personId: z.number().optional(),

--- a/api/src/services/anmeldung/anmeldungGliederungList.ts
+++ b/api/src/services/anmeldung/anmeldungGliederungList.ts
@@ -2,7 +2,7 @@ import { AnmeldungStatus, Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import { ZPaginationSchema } from '../../types/defineQuery.js'
 import { getGliederungRequireAdmin } from '../../util/getGliederungRequireAdmin.js'
 
@@ -29,10 +29,10 @@ const where = (filter: { gliederungId: number; unterveranstaltungId?: number; ve
   }
 }
 
-export const anmeldungGliederungdListProcedure = defineProcedure({
+export const anmeldungGliederungdListProcedure = defineProtectedProcedure({
   key: 'gliederungList',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema: z.strictObject({
     pagination: ZPaginationSchema,
     filter: filter,
@@ -95,10 +95,10 @@ export const anmeldungGliederungdListProcedure = defineProcedure({
   },
 })
 
-export const anmeldungGliederungCountProcedure = defineProcedure({
+export const anmeldungGliederungCountProcedure = defineProtectedProcedure({
   key: 'gliederungCount',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema: z.strictObject({
     filter: filter,
   }),

--- a/api/src/services/anmeldung/anmeldungProtectedGet.ts
+++ b/api/src/services/anmeldung/anmeldungProtectedGet.ts
@@ -2,7 +2,7 @@ import { Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 
 const inputSchema = z.strictObject({
   anmeldungId: z.number().optional(),
@@ -11,10 +11,10 @@ const inputSchema = z.strictObject({
 
 export type AnmeldungProtectedGetSchema = z.infer<typeof inputSchema>
 
-export const anmeldungProtectedGetProcedure = defineProcedure({
+export const anmeldungProtectedGetProcedure = defineProtectedProcedure({
   key: 'gliederungGet',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema,
   handler: ({ input }) =>
     prisma.anmeldung.findMany({

--- a/api/src/services/anmeldung/anmeldungVerwaltungAblehnen.ts
+++ b/api/src/services/anmeldung/anmeldungVerwaltungAblehnen.ts
@@ -2,15 +2,15 @@ import { AnmeldungStatus, Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import logActivity from '../../util/activity.js'
 import { getGliederungRequireAdmin } from '../../util/getGliederungRequireAdmin.js'
 import { sendMail } from '../../util/mail.js'
 
-export const anmeldungVerwaltungAblehnenProcedure = defineProcedure({
+export const anmeldungVerwaltungAblehnenProcedure = defineProtectedProcedure({
   key: 'verwaltungAblehnen',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema: z.strictObject({
     anmeldungId: z.number().int(),
   }),

--- a/api/src/services/anmeldung/anmeldungVerwaltungGet.ts
+++ b/api/src/services/anmeldung/anmeldungVerwaltungGet.ts
@@ -2,12 +2,12 @@ import { Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 
-export const anmeldungVerwaltungGetProcedure = defineProcedure({
+export const anmeldungVerwaltungGetProcedure = defineProtectedProcedure({
   key: 'verwaltungGet',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: z.strictObject({
     anmeldungId: z.number().optional(),
     personId: z.number().optional(),

--- a/api/src/services/anmeldung/anmeldungVerwaltungList.ts
+++ b/api/src/services/anmeldung/anmeldungVerwaltungList.ts
@@ -2,7 +2,7 @@ import { AnmeldungStatus, Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import { ZPaginationSchema } from '../../types/defineQuery.js'
 
 const filter = z.strictObject({
@@ -25,10 +25,10 @@ const where = (filter: { unterveranstaltungId?: number; veranstaltungId?: number
   }
 }
 
-export const anmeldungVerwaltungListProcedure = defineProcedure({
+export const anmeldungVerwaltungListProcedure = defineProtectedProcedure({
   key: 'verwaltungList',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: z.strictObject({
     pagination: ZPaginationSchema,
     filter: filter,
@@ -89,10 +89,10 @@ export const anmeldungVerwaltungListProcedure = defineProcedure({
   },
 })
 
-export const anmeldungVerwaltungCountProcedure = defineProcedure({
+export const anmeldungVerwaltungCountProcedure = defineProtectedProcedure({
   key: 'verwaltungCount',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: z.strictObject({
     filter: filter,
   }),

--- a/api/src/services/anmeldung/anmeldungVerwaltungStorno.ts
+++ b/api/src/services/anmeldung/anmeldungVerwaltungStorno.ts
@@ -2,15 +2,15 @@ import { AnmeldungStatus, Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import logActivity from '../../util/activity.js'
 import { getGliederungRequireAdmin } from '../../util/getGliederungRequireAdmin.js'
 import { sendMail } from '../../util/mail.js'
 
-export const anmeldungVerwaltungStornoProcedure = defineProcedure({
+export const anmeldungVerwaltungStornoProcedure = defineProtectedProcedure({
   key: 'verwaltungStorno',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema: z.strictObject({
     anmeldungId: z.number().int(),
   }),

--- a/api/src/services/authentication/authenticationLogin.ts
+++ b/api/src/services/authentication/authenticationLogin.ts
@@ -2,12 +2,11 @@ import { z } from 'zod'
 
 import { authenticationLogin } from '../../authentication.js'
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { definePublicProcedure } from '../../types/defineProcedure.js'
 
-export const authenticationLoginProcedure = defineProcedure({
+export const authenticationLoginProcedure = definePublicProcedure({
   key: 'login',
   method: 'mutation',
-  protection: { type: 'public' },
   inputSchema: z.strictObject({
     email: z.string(),
     password: z.string(),

--- a/api/src/services/customFields/customFieldsGet.ts
+++ b/api/src/services/customFields/customFieldsGet.ts
@@ -3,12 +3,12 @@ import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 
-export const customFieldsGet = defineProcedure({
+export const customFieldsGet = defineProtectedProcedure({
   key: 'get',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema: z.strictObject({
     id: z.number(),
   }),

--- a/api/src/services/customFields/customFieldsUnterveranstaltungCreate.ts
+++ b/api/src/services/customFields/customFieldsUnterveranstaltungCreate.ts
@@ -2,14 +2,14 @@ import { Role } from '@prisma/client'
 import { z } from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 
 import { customFieldSchema } from './schema/customField.schema.js'
 
-export const customFieldsUnterveranstaltungCreate = defineProcedure({
+export const customFieldsUnterveranstaltungCreate = defineProtectedProcedure({
   key: 'unterveranstaltungCreate',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema: z.strictObject({
     unterveranstaltungId: z.number(),
     data: customFieldSchema,

--- a/api/src/services/customFields/customFieldsVeranstaltungDelete.ts
+++ b/api/src/services/customFields/customFieldsVeranstaltungDelete.ts
@@ -3,12 +3,12 @@ import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 
-export const customFieldsVeranstaltungDelete = defineProcedure({
+export const customFieldsVeranstaltungDelete = defineProtectedProcedure({
   key: 'veranstaltungDelete',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: z.strictObject({
     veranstaltungId: z.number(),
     fieldId: z.number(),


### PR DESCRIPTION
Refactor services in the API to use `defineProtectedProcedure` or `definePublicProcedure` instead of `defineProcedure`.

* Replace `defineProcedure` with `defineProtectedProcedure` in files where the protection type is `restrictToRoleIds` and move `roleIds` to the root of the param:
  - `api/src/services/account/accountActivate.ts`
  - `api/src/services/account/accountChangePassword.ts`
  - `api/src/services/account/accountEmailConfirmRequest.ts`
  - `api/src/services/account/accountVerwaltungCreate.ts`
  - `api/src/services/account/accountVerwaltungList.ts`
  - `api/src/services/account/accountVerwaltungRemove.ts`
  - `api/src/services/activity/activityList.ts`
  - `api/src/services/anmeldung/anmeldungGliederungGet.ts`
  - `api/src/services/anmeldung/anmeldungGliederungList.ts`
  - `api/src/services/anmeldung/anmeldungProtectedGet.ts`
  - `api/src/services/anmeldung/anmeldungVerwaltungAblehnen.ts`
  - `api/src/services/anmeldung/anmeldungVerwaltungGet.ts`
  - `api/src/services/anmeldung/anmeldungVerwaltungList.ts`
  - `api/src/services/anmeldung/anmeldungVerwaltungStorno.ts`
  - `api/src/services/customFields/customFieldsGet.ts`
  - `api/src/services/customFields/customFieldsUnterveranstaltungCreate.ts`
  - `api/src/services/customFields/customFieldsVeranstaltungDelete.ts`

* Replace `defineProcedure` with `definePublicProcedure` in files where the protection type is `public`:
  - `api/src/services/address/addressFindAddress.ts`
  - `api/src/services/authentication/authenticationLogin.ts`

