### PR TITLE
Refactor all services in the API that use defineProcedure

### DIFF
--- a/api/src/services/account/accountEmailConfirm.ts
+++ b/api/src/services/account/accountEmailConfirm.ts
@@ -1,12 +1,11 @@
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { definePublicProcedure } from '../../types/defineProcedure.js'
 
-export const accountEmailConfirmProcedure = defineProcedure({
+export const accountEmailConfirmProcedure = definePublicProcedure({
   key: 'emailConfirm',
   method: 'mutation',
-  protection: { type: 'public' },
   inputSchema: z.strictObject({
     activationToken: z.string(),
   }),

--- a/api/src/services/account/accountGliederungAdminCreate.ts
+++ b/api/src/services/account/accountGliederungAdminCreate.ts
@@ -6,7 +6,7 @@ import z from 'zod'
 import config from '../../config.js'
 import prisma from '../../prisma.js'
 import { ZOauthRegisterJwtPayloadSchema } from '../../routes/connect.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { definePublicProcedure } from '../../types/defineProcedure.js'
 
 import { sendMailConfirmEmailRequest } from './helpers/sendMailConfirmEmailRequest.js'
 import { getAccountCreateData } from './schema/account.schema.js'
@@ -24,10 +24,9 @@ const ZAccountGliederungAdminCreateInput = z.strictObject({
   }),
 })
 
-export const accountGliederungAdminCreateProcedure = defineProcedure({
+export const accountGliederungAdminCreateProcedure = definePublicProcedure({
   key: 'gliederungAdminCreate',
   method: 'mutation',
-  protection: { type: 'public' },
   inputSchema: ZAccountGliederungAdminCreateInput,
   async handler(options) {
     let dlrgOauthId: undefined | string = undefined

--- a/api/src/services/account/accountVerwaltungGet.ts
+++ b/api/src/services/account/accountVerwaltungGet.ts
@@ -2,12 +2,12 @@ import { Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 
-export const accountVerwaltungGetProcedure = defineProcedure({
+export const accountVerwaltungGetProcedure = defineProtectedProcedure({
   key: 'verwaltungGet',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: z.strictObject({
     id: z.number().int(),
   }),

--- a/api/src/services/account/accountVerwaltungPatch.ts
+++ b/api/src/services/account/accountVerwaltungPatch.ts
@@ -3,14 +3,14 @@ import z from 'zod'
 
 import { AccountStatusMapping } from '../../enumMappings/index.js'
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import logActivity from '../../util/activity.js'
 import { sendMail } from '../../util/mail.js'
 
-export const accountVerwaltungPatchProcedure = defineProcedure({
+export const accountVerwaltungPatchProcedure = defineProtectedProcedure({
   key: 'verwaltungPatch',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: z.strictObject({
     id: z.number().int(),
     data: z.strictObject({

--- a/api/src/services/anmeldung/anmeldungGliederungPatch.ts
+++ b/api/src/services/anmeldung/anmeldungGliederungPatch.ts
@@ -2,12 +2,12 @@ import { Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 
-export const anmeldungGliederungPatchProcedure = defineProcedure({
+export const anmeldungGliederungPatchProcedure = defineProtectedProcedure({
   key: 'gliederungPatch',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema: z.strictObject({
     id: z.number().int(),
     data: z.strictObject({

--- a/api/src/services/anmeldung/anmeldungPublicCreate.ts
+++ b/api/src/services/anmeldung/anmeldungPublicCreate.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 
 import prisma from '../../prisma.js'
 import { customFieldValuesCreateMany, defineCustomFieldValues } from '../../types/defineCustomFieldValues.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { definePublicProcedure } from '../../types/defineProcedure.js'
 import logActivity from '../../util/activity.js'
 import { sendMail } from '../../util/mail.js'
 import { personSchema, getPersonCreateData } from '../person/schema/person.schema.js'
@@ -124,10 +124,9 @@ export async function handle(input: z.infer<typeof inputSchema>, isPublic: boole
   return person
 }
 
-export const anmeldungPublicCreateProcedure = defineProcedure({
+export const anmeldungPublicCreateProcedure = definePublicProcedure({
   key: 'publicCreate',
   method: 'mutation',
-  protection: { type: 'public' },
   inputSchema: inputSchema,
   async handler(options) {
     await handle(options.input, true)

--- a/api/src/services/anmeldung/anmeldungVerwaltungAnnehmen.ts
+++ b/api/src/services/anmeldung/anmeldungVerwaltungAnnehmen.ts
@@ -2,15 +2,15 @@ import { AnmeldungStatus, Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import logActivity from '../../util/activity.js'
 import { getGliederungRequireAdmin } from '../../util/getGliederungRequireAdmin.js'
 import { sendMail } from '../../util/mail.js'
 
-export const anmeldungVerwaltungAnnehmenProcedure = defineProcedure({
+export const anmeldungVerwaltungAnnehmenProcedure = defineProtectedProcedure({
   key: 'verwaltungAnnehmen',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema: z.strictObject({
     anmeldungId: z.number().int(),
   }),

--- a/api/src/services/anmeldung/anmeldungVerwaltungPatch.ts
+++ b/api/src/services/anmeldung/anmeldungVerwaltungPatch.ts
@@ -2,12 +2,12 @@ import { Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 
-export const anmeldungVerwaltungPatchProcedure = defineProcedure({
+export const anmeldungVerwaltungPatchProcedure = defineProtectedProcedure({
   key: 'verwaltungPatch',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema: z.strictObject({
     id: z.number().int(),
     data: z.strictObject({

--- a/api/src/services/customFields/customFieldValuesUpdate.ts
+++ b/api/src/services/customFields/customFieldValuesUpdate.ts
@@ -2,14 +2,14 @@ import { Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import logActivity from '../../util/activity.js'
 import { getGliederungRequireAdmin } from '../../util/getGliederungRequireAdmin.js'
 
-export const customFieldValuesUpdate = defineProcedure({
+export const customFieldValuesUpdate = defineProtectedProcedure({
   key: 'valuesUpdate',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema: z.strictObject({
     data: z.array(
       z.strictObject({

--- a/api/src/services/customFields/customFieldsList.ts
+++ b/api/src/services/customFields/customFieldsList.ts
@@ -1,12 +1,11 @@
 import { z } from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { definePublicProcedure } from '../../types/defineProcedure.js'
 
-export const customFieldsList = defineProcedure({
+export const customFieldsList = definePublicProcedure({
   key: 'list',
   method: 'query',
-  protection: { type: 'public' },
   inputSchema: z.strictObject({
     entity: z.enum(['veranstaltung', 'unterveranstaltung']).optional(),
     entityId: z.number(),

--- a/api/src/services/customFields/customFieldsVeranstaltungCreate.ts
+++ b/api/src/services/customFields/customFieldsVeranstaltungCreate.ts
@@ -2,14 +2,14 @@ import { Role } from '@prisma/client'
 import { z } from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 
 import { customFieldSchema } from './schema/customField.schema.js'
 
-export const customFieldsVeranstaltungCreate = defineProcedure({
+export const customFieldsVeranstaltungCreate = defineProtectedProcedure({
   key: 'veranstaltungCreate',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: z.strictObject({
     veranstaltungId: z.number(),
     data: customFieldSchema,

--- a/api/src/services/customFields/customFieldsVeranstaltungUpdate.ts
+++ b/api/src/services/customFields/customFieldsVeranstaltungUpdate.ts
@@ -2,14 +2,14 @@ import { Role } from '@prisma/client'
 import { z } from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 
 import { customFieldSchema } from './schema/customField.schema.js'
 
-export const customFieldsVeranstaltungUpdate = defineProcedure({
+export const customFieldsVeranstaltungUpdate = defineProtectedProcedure({
   key: 'veranstaltungUpdate',
   method: 'mutation',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: z.strictObject({
     fieldId: z.number(),
     data: customFieldSchema,

--- a/api/src/services/file/fileCreate.ts
+++ b/api/src/services/file/fileCreate.ts
@@ -7,15 +7,12 @@ import z from 'zod'
 import { azureStorage } from '../../azureStorage.js'
 import config from '../../config.js'
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 
-export const fileCreateProcedure = defineProcedure({
+export const fileCreateProcedure = defineProtectedProcedure({
   key: 'fileCreate',
   method: 'mutation',
-  protection: {
-    type: 'restrictToRoleIds',
-    roleIds: ['ADMIN', 'GLIEDERUNG_ADMIN'],
-  },
+  roleIds: ['ADMIN', 'GLIEDERUNG_ADMIN'],
   inputSchema: z.strictObject({
     mimetype: z.string(),
   }),

--- a/api/src/services/file/fileGetUrl.ts
+++ b/api/src/services/file/fileGetUrl.ts
@@ -5,14 +5,13 @@ import z from 'zod'
 import { azureStorage } from '../../azureStorage.js'
 import config from '../../config.js'
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { definePublicProcedure } from '../../types/defineProcedure.js'
 
 const downloadUrlLifespan = 60 * 60 // 1 hour
 
-export const fileGetUrlActionProcedure = defineProcedure({
+export const fileGetUrlActionProcedure = definePublicProcedure({
   key: 'fileGetUrl',
   method: 'query',
-  protection: { type: 'public' },
   inputSchema: z.strictObject({
     id: z.string().uuid(),
   }),

--- a/api/src/services/gliederung/gliederungList.ts
+++ b/api/src/services/gliederung/gliederungList.ts
@@ -2,7 +2,7 @@ import { Prisma, Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import { defineQuery, getOrderBy } from '../../types/defineQuery.js'
 
 const inputSchema = defineQuery({
@@ -16,10 +16,10 @@ const inputSchema = defineQuery({
 })
 type TInput = z.infer<typeof inputSchema>
 
-export const gliederungListProcedure = defineProcedure({
+export const gliederungListProcedure = defineProtectedProcedure({
   key: 'list',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema,
   async handler(options) {
     const { skip, take } = options.input.pagination
@@ -39,10 +39,10 @@ export const gliederungListProcedure = defineProcedure({
   },
 })
 
-export const gliederungCountProcedure = defineProcedure({
+export const gliederungCountProcedure = defineProtectedProcedure({
   key: 'count',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: inputSchema.pick({ filter: true }),
   async handler(options) {
     const list = await prisma.gliederung.count({

--- a/api/src/services/gliederung/gliederungPublicList.ts
+++ b/api/src/services/gliederung/gliederungPublicList.ts
@@ -1,13 +1,12 @@
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { definePublicProcedure } from '../../types/defineProcedure.js'
 import { defineQuery, getOrderBy } from '../../types/defineQuery.js'
 
-export const gliederungPublicListProcedure = defineProcedure({
+export const gliederungPublicListProcedure = definePublicProcedure({
   key: 'publicList',
   method: 'query',
-  protection: { type: 'public' },
   inputSchema: defineQuery({
     filter: z.strictObject({
       name: z.string().optional(),

--- a/api/src/services/ort/ortList.ts
+++ b/api/src/services/ort/ortList.ts
@@ -2,7 +2,7 @@ import { Role, type Prisma } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import { defineQuery } from '../../types/defineQuery.js'
 
 const inputSchema = defineQuery({
@@ -50,10 +50,10 @@ async function getWhere(
   return where
 }
 
-export const ortListProcedure = defineProcedure({
+export const ortListProcedure = defineProtectedProcedure({
   key: 'list',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema,
   async handler(options) {
     const { skip, take } = options.input.pagination
@@ -71,10 +71,10 @@ export const ortListProcedure = defineProcedure({
   },
 })
 
-export const ortCountProcedure = defineProcedure({
+export const ortCountProcedure = defineProtectedProcedure({
   key: 'count',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: inputSchema.pick({ filter: true }),
   async handler(options) {
     return await prisma.ort.count({

--- a/api/src/services/person/personAuthenticatedGet.ts
+++ b/api/src/services/person/personAuthenticatedGet.ts
@@ -2,12 +2,12 @@ import { Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 
-export const personAuthenticatedGetProcedure = defineProcedure({
+export const personAuthenticatedGetProcedure = defineProtectedProcedure({
   key: 'authenticatedGet',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema: z.undefined(),
   async handler(options) {
     return prisma.account.findUniqueOrThrow({

--- a/api/src/services/person/personList.ts
+++ b/api/src/services/person/personList.ts
@@ -2,7 +2,7 @@ import { Prisma, Role } from '@prisma/client'
 import z from 'zod'
 
 import prisma from '../../prisma.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import { defineQuery, getOrderBy } from '../../types/defineQuery.js'
 
 const inputSchema = defineQuery({
@@ -20,10 +20,10 @@ const inputSchema = defineQuery({
 
 type TInput = z.infer<typeof inputSchema>
 
-export const personListProcedure = defineProcedure({
+export const personListProcedure = defineProtectedProcedure({
   key: 'list',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema,
   async handler(options) {
     const { skip, take } = options.input.pagination
@@ -63,10 +63,10 @@ export const personListProcedure = defineProcedure({
   },
 })
 
-export const personCountProcedure = defineProcedure({
+export const personCountProcedure = defineProtectedProcedure({
   key: 'count',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN] },
+  roleIds: [Role.ADMIN],
   inputSchema: inputSchema.pick({ filter: true }),
   async handler(options) {
     const total = await prisma.person.count({

--- a/api/src/services/search/search.ts
+++ b/api/src/services/search/search.ts
@@ -3,13 +3,13 @@ import type { MultiSearchQuery } from 'meilisearch'
 import z from 'zod'
 
 import { meilisearchClient } from '../../meilisearch/index.js'
-import { defineProcedure } from '../../types/defineProcedure.js'
+import { defineProtectedProcedure } from '../../types/defineProcedure.js'
 import { getGliederungRequireAdmin } from '../../util/getGliederungRequireAdmin.js'
 
-export const searchProcedure = defineProcedure({
+export const searchProcedure = defineProtectedProcedure({
   key: 'search',
   method: 'query',
-  protection: { type: 'restrictToRoleIds', roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN] },
+  roleIds: [Role.ADMIN, Role.GLIEDERUNG_ADMIN],
   inputSchema: z.strictObject({
     term: z.string(),
   }),


### PR DESCRIPTION
Refactor all services in the API that use `defineProcedure`.

* Rename `defineProcedure` to `definePublicProcedure` in:
  - `api/src/services/account/accountEmailConfirm.ts`
  - `api/src/services/account/accountGliederungAdminCreate.ts`
  - `api/src/services/anmeldung/anmeldungPublicCreate.ts`
  - `api/src/services/customFields/customFieldsList.ts`
  - `api/src/services/file/fileGetUrl.ts`
  - `api/src/services/gliederung/gliederungPublicList.ts`

* Rename `defineProcedure` to `defineProtectedProcedure` and move `roleIds` to the root of the param in:
  - `api/src/services/account/accountVerwaltungGet.ts`
  - `api/src/services/account/accountVerwaltungPatch.ts`
  - `api/src/services/anmeldung/anmeldungGliederungPatch.ts`
  - `api/src/services/anmeldung/anmeldungVerwaltungAnnehmen.ts`
  - `api/src/services/anmeldung/anmeldungVerwaltungPatch.ts`
  - `api/src/services/customFields/customFieldsVeranstaltungCreate.ts`
  - `api/src/services/customFields/customFieldsVeranstaltungUpdate.ts`
  - `api/src/services/customFields/customFieldValuesUpdate.ts`
  - `api/src/services/file/fileCreate.ts`
  - `api/src/services/gliederung/gliederungList.ts`
  - `api/src/services/ort/ortList.ts`
  - `api/src/services/person/personAuthenticatedGet.ts`
  - `api/src/services/person/personList.ts`
  - `api/src/services/search/search.ts`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/codeanker/brahmsee.digital/pull/181?shareId=152e8080-4622-485f-bf6f-1815951f468d).