### PR TITLE
feat: faq sort + feat: faq-delete + fix: faq create after edit bug 

### DIFF
--- a/apps/api/prisma/migrations/20260311172026_faq_sort_order/migration.sql
+++ b/apps/api/prisma/migrations/20260311172026_faq_sort_order/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "faq_categories" ADD COLUMN     "sortOrder" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "faqs" ADD COLUMN     "sortOrder" INTEGER NOT NULL DEFAULT 0;

--- a/apps/api/prisma/migrations/20260311172026_faq_sort_order/migration.sql
+++ b/apps/api/prisma/migrations/20260311172026_faq_sort_order/migration.sql
@@ -1,5 +1,5 @@
 -- AlterTable
-ALTER TABLE "faq_categories" ADD COLUMN     "sortOrder" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "faq_categories" ADD COLUMN     "order" INTEGER NOT NULL DEFAULT 0;
 
 -- AlterTable
-ALTER TABLE "faqs" ADD COLUMN     "sortOrder" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "faqs" ADD COLUMN     "order" INTEGER NOT NULL DEFAULT 0;

--- a/apps/api/prisma/schema/Faq.prisma
+++ b/apps/api/prisma/schema/Faq.prisma
@@ -1,6 +1,7 @@
 model FaqCategory {
-  id   String @id @default(uuid(7))
-  name String
+  id        String @id @default(uuid(7))
+  name      String
+  sortOrder Int    @default(0)
 
   unterveranstaltungId String
   unterveranstaltung   Unterveranstaltung @relation(fields: [unterveranstaltungId], references: [id])
@@ -11,9 +12,10 @@ model FaqCategory {
 }
 
 model Faq {
-  id       String @id @default(uuid(7))
-  question String
-  answer   String
+  id        String @id @default(uuid(7))
+  question  String
+  answer    String
+  sortOrder Int    @default(0)
 
   categoryId String
   category   FaqCategory @relation(fields: [categoryId], references: [id])

--- a/apps/api/prisma/schema/Faq.prisma
+++ b/apps/api/prisma/schema/Faq.prisma
@@ -1,7 +1,7 @@
 model FaqCategory {
-  id        String @id @default(uuid(7))
-  name      String
-  sortOrder Int    @default(0)
+  id    String @id @default(uuid(7))
+  name  String
+  order Int    @default(0)
 
   unterveranstaltungId String
   unterveranstaltung   Unterveranstaltung @relation(fields: [unterveranstaltungId], references: [id])
@@ -12,10 +12,10 @@ model FaqCategory {
 }
 
 model Faq {
-  id        String @id @default(uuid(7))
-  question  String
-  answer    String
-  sortOrder Int    @default(0)
+  id       String @id @default(uuid(7))
+  question String
+  answer   String
+  order    Int    @default(0)
 
   categoryId String
   category   FaqCategory @relation(fields: [categoryId], references: [id])

--- a/apps/api/src/services/faqs/faqCreateProcedure.ts
+++ b/apps/api/src/services/faqs/faqCreateProcedure.ts
@@ -12,10 +12,22 @@ export const faqCreateProcedure = defineProtectedMutateProcedure({
     faq: faqSchema,
   }),
   handler: async ({ input: { faq, unterveranstaltungId } }) => {
+    const [maxCategoryOrder, maxFaqOrder] = await Promise.all([
+      prisma.faqCategory.aggregate({
+        where: { unterveranstaltungId },
+        _max: { sortOrder: true },
+      }),
+      prisma.faq.aggregate({
+        where: { category: { unterveranstaltungId } },
+        _max: { sortOrder: true },
+      }),
+    ])
+
     await prisma.faq.create({
       data: {
         question: faq.question,
         answer: faq.answer,
+        sortOrder: (maxFaqOrder._max.sortOrder ?? -1) + 1,
         unterveranstaltung: {
           connect: {
             id: unterveranstaltungId,
@@ -26,6 +38,7 @@ export const faqCreateProcedure = defineProtectedMutateProcedure({
             create: {
               name: faq.category,
               unterveranstaltungId,
+              sortOrder: (maxCategoryOrder._max.sortOrder ?? -1) + 1,
             },
             where: {
               name_unterveranstaltungId: {

--- a/apps/api/src/services/faqs/faqCreateProcedure.ts
+++ b/apps/api/src/services/faqs/faqCreateProcedure.ts
@@ -15,11 +15,11 @@ export const faqCreateProcedure = defineProtectedMutateProcedure({
     const [maxCategoryOrder, maxFaqOrder] = await Promise.all([
       prisma.faqCategory.aggregate({
         where: { unterveranstaltungId },
-        _max: { sortOrder: true },
+        _max: { order: true },
       }),
       prisma.faq.aggregate({
         where: { category: { unterveranstaltungId } },
-        _max: { sortOrder: true },
+        _max: { order: true },
       }),
     ])
 
@@ -27,7 +27,7 @@ export const faqCreateProcedure = defineProtectedMutateProcedure({
       data: {
         question: faq.question,
         answer: faq.answer,
-        sortOrder: (maxFaqOrder._max.sortOrder ?? -1) + 1,
+        order: (maxFaqOrder._max.order ?? -1) + 1,
         unterveranstaltung: {
           connect: {
             id: unterveranstaltungId,
@@ -38,7 +38,7 @@ export const faqCreateProcedure = defineProtectedMutateProcedure({
             create: {
               name: faq.category,
               unterveranstaltungId,
-              sortOrder: (maxCategoryOrder._max.sortOrder ?? -1) + 1,
+              order: (maxCategoryOrder._max.order ?? -1) + 1,
             },
             where: {
               name_unterveranstaltungId: {

--- a/apps/api/src/services/faqs/faqDeleteProcecure.ts
+++ b/apps/api/src/services/faqs/faqDeleteProcecure.ts
@@ -2,12 +2,39 @@ import z from 'zod'
 
 import prisma from '../../prisma.js'
 import { defineProtectedMutateProcedure } from '../../types/defineProcedure.js'
+import { getGliederungRequireAdmin } from '../../util/getGliederungRequireAdmin.js'
+import { TRPCError } from '@trpc/server'
 
 export const faqDeleteProcedure = defineProtectedMutateProcedure({
   key: 'delete',
   roleIds: ['ADMIN', 'GLIEDERUNG_ADMIN'],
   inputSchema: z.string().uuid(),
-  handler: async ({ input }) => {
+  handler: async ({ ctx, input }) => {
+    const gliederung = await getGliederungRequireAdmin(ctx.accountId)
+    const unterveranstaltungIds = (
+      await prisma.unterveranstaltung.findMany({
+        where: { gliederungId: gliederung.id },
+        select: { id: true },
+      })
+    ).map((u) => u.id)
+
+    const faq = await prisma.faq.findUnique({
+      where: {
+        id: input,
+        unterveranstaltung: {
+          every: {
+            id: { in: unterveranstaltungIds },
+          },
+        },
+      },
+      select: {
+        id: true,
+      },
+    })
+    if (!faq) {
+      throw new TRPCError({ code: 'FORBIDDEN', message: `FAQ do not belong to accounts gliederung` })
+    }
+
     await prisma.faq.delete({
       where: {
         id: input,

--- a/apps/api/src/services/faqs/faqListProcedure.ts
+++ b/apps/api/src/services/faqs/faqListProcedure.ts
@@ -13,24 +13,37 @@ export async function listFaqs(unterveranstaltungId: string) {
         },
       },
     },
+    orderBy: {
+      sortOrder: 'asc',
+    },
     select: {
       id: true,
       question: true,
       answer: true,
+      sortOrder: true,
       category: {
         select: {
+          id: true,
           name: true,
+          sortOrder: true,
         },
       },
     },
   })
 
   const groups = groupBy(
-    list.map((v) => ({ ...v, category: v.category.name })),
+    list.map((v) => ({
+      ...v,
+      category: v.category.name,
+      categoryId: v.category.id,
+      categorySortOrder: v.category.sortOrder,
+    })),
     ({ category }) => category
   )
 
-  return Object.fromEntries(Object.entries(groups).sort(([a], [b]) => a.localeCompare(b)))
+  return Object.fromEntries(
+    Object.entries(groups).sort(([, a], [, b]) => (a[0]?.categorySortOrder ?? 0) - (b[0]?.categorySortOrder ?? 0))
+  )
 }
 
 export const faqListProcedure = defineProtectedQueryProcedure({

--- a/apps/api/src/services/faqs/faqListProcedure.ts
+++ b/apps/api/src/services/faqs/faqListProcedure.ts
@@ -14,18 +14,18 @@ export async function listFaqs(unterveranstaltungId: string) {
       },
     },
     orderBy: {
-      sortOrder: 'asc',
+      order: 'asc',
     },
     select: {
       id: true,
       question: true,
       answer: true,
-      sortOrder: true,
+      order: true,
       category: {
         select: {
           id: true,
           name: true,
-          sortOrder: true,
+          order: true,
         },
       },
     },
@@ -36,13 +36,13 @@ export async function listFaqs(unterveranstaltungId: string) {
       ...v,
       category: v.category.name,
       categoryId: v.category.id,
-      categorySortOrder: v.category.sortOrder,
+      categoryOrder: v.category.order,
     })),
     ({ category }) => category
   )
 
   return Object.fromEntries(
-    Object.entries(groups).sort(([, a], [, b]) => (a[0]?.categorySortOrder ?? 0) - (b[0]?.categorySortOrder ?? 0))
+    Object.entries(groups).sort(([, a], [, b]) => (a[0]?.categoryOrder ?? 0) - (b[0]?.categoryOrder ?? 0))
   )
 }
 

--- a/apps/api/src/services/faqs/faqReorderProcedure.ts
+++ b/apps/api/src/services/faqs/faqReorderProcedure.ts
@@ -1,7 +1,10 @@
 import z from 'zod'
 
 import prisma from '../../prisma.js'
+import { TRPCError } from '@trpc/server'
+import { Role } from '@prisma/client'
 import { defineProtectedMutateProcedure } from '../../types/defineProcedure.js'
+import { getGliederungRequireAdmin } from '../../util/getGliederungRequireAdmin.js'
 
 export const faqReorderProcedure = defineProtectedMutateProcedure({
   key: 'reorder',
@@ -21,7 +24,59 @@ export const faqReorderProcedure = defineProtectedMutateProcedure({
       })
     ),
   }),
-  handler: async ({ input: { faqOrder, categoryOrder } }) => {
+  handler: async ({ ctx, input: { faqOrder, categoryOrder } }) => {
+    /// Check permissions for FAQs and categories
+    if (ctx.account.role !== Role.ADMIN) {
+      const gliederung = await getGliederungRequireAdmin(ctx.accountId)
+      const unterveranstaltungIds = (
+        await prisma.unterveranstaltung.findMany({
+          where: { gliederungId: gliederung.id },
+          select: { id: true },
+        })
+      ).map((u) => u.id)
+
+      const faqs = await prisma.faq.findMany({
+        where: { id: { in: faqOrder.map((f) => f.id) } },
+        select: {
+          id: true,
+          unterveranstaltung: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      })
+      for (const faq of faqs) {
+        const unterveranstaltungId = faq.unterveranstaltung[0]?.id
+        if (!unterveranstaltungId || !unterveranstaltungIds.includes(unterveranstaltungId)) {
+          throw new TRPCError({ code: 'FORBIDDEN', message: `FAQ '${faq.id}' do not belong to accounts gliederung` })
+        }
+      }
+
+      const categoryIds = [...new Set([...categoryOrder.map((c) => c.id), ...faqOrder.map((f) => f.categoryId)])]
+      const categories = await prisma.faqCategory.findMany({
+        where: { id: { in: categoryIds } },
+        select: {
+          id: true,
+          unterveranstaltung: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      })
+      for (const category of categories) {
+        const unterveranstaltungId = category.unterveranstaltung.id
+        if (!unterveranstaltungId || !unterveranstaltungIds.includes(unterveranstaltungId)) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: `FAQ Category '${category.id}' do not belong to accounts gliederung`,
+          })
+        }
+      }
+    }
+
+    /// Perform updates in a transaction
     await prisma.$transaction([
       ...faqOrder.map(({ id, sortOrder, categoryId }) =>
         prisma.faq.update({

--- a/apps/api/src/services/faqs/faqReorderProcedure.ts
+++ b/apps/api/src/services/faqs/faqReorderProcedure.ts
@@ -13,14 +13,14 @@ export const faqReorderProcedure = defineProtectedMutateProcedure({
     faqOrder: z.array(
       z.strictObject({
         id: z.string().uuid(),
-        sortOrder: z.number().int().min(0),
+        order: z.number().int().min(0),
         categoryId: z.string().uuid(),
       })
     ),
     categoryOrder: z.array(
       z.strictObject({
         id: z.string().uuid(),
-        sortOrder: z.number().int().min(0),
+        order: z.number().int().min(0),
       })
     ),
   }),
@@ -78,16 +78,16 @@ export const faqReorderProcedure = defineProtectedMutateProcedure({
 
     /// Perform updates in a transaction
     await prisma.$transaction([
-      ...faqOrder.map(({ id, sortOrder, categoryId }) =>
+      ...faqOrder.map(({ id, order, categoryId }) =>
         prisma.faq.update({
           where: { id },
-          data: { sortOrder, categoryId },
+          data: { order, categoryId },
         })
       ),
-      ...categoryOrder.map(({ id, sortOrder }) =>
+      ...categoryOrder.map(({ id, order }) =>
         prisma.faqCategory.update({
           where: { id },
-          data: { sortOrder },
+          data: { order },
         })
       ),
     ])

--- a/apps/api/src/services/faqs/faqReorderProcedure.ts
+++ b/apps/api/src/services/faqs/faqReorderProcedure.ts
@@ -1,0 +1,40 @@
+import z from 'zod'
+
+import prisma from '../../prisma.js'
+import { defineProtectedMutateProcedure } from '../../types/defineProcedure.js'
+
+export const faqReorderProcedure = defineProtectedMutateProcedure({
+  key: 'reorder',
+  roleIds: ['ADMIN', 'GLIEDERUNG_ADMIN'],
+  inputSchema: z.strictObject({
+    faqOrder: z.array(
+      z.strictObject({
+        id: z.string().uuid(),
+        sortOrder: z.number().int().min(0),
+        categoryId: z.string().uuid(),
+      })
+    ),
+    categoryOrder: z.array(
+      z.strictObject({
+        id: z.string().uuid(),
+        sortOrder: z.number().int().min(0),
+      })
+    ),
+  }),
+  handler: async ({ input: { faqOrder, categoryOrder } }) => {
+    await prisma.$transaction([
+      ...faqOrder.map(({ id, sortOrder, categoryId }) =>
+        prisma.faq.update({
+          where: { id },
+          data: { sortOrder, categoryId },
+        })
+      ),
+      ...categoryOrder.map(({ id, sortOrder }) =>
+        prisma.faqCategory.update({
+          where: { id },
+          data: { sortOrder },
+        })
+      ),
+    ])
+  },
+})

--- a/apps/api/src/services/faqs/faqs.router.ts
+++ b/apps/api/src/services/faqs/faqs.router.ts
@@ -4,6 +4,7 @@ import { faqCreateProcedure } from './faqCreateProcedure.js'
 import { faqDeleteProcedure } from './faqDeleteProcecure.js'
 import { faqCategorySearchProcedure, faqListProcedure } from './faqListProcedure.js'
 import { faqUpdateProcedure } from './faqUpdateProcedure.js'
+import { faqReorderProcedure } from './faqReorderProcedure.js'
 
 // Import Routes here - do not delete this line
 
@@ -12,6 +13,7 @@ export const faqsRouter = mergeRouters(
   faqCategorySearchProcedure,
   faqCreateProcedure,
   faqUpdateProcedure,
-  faqDeleteProcedure
+  faqDeleteProcedure,
+  faqReorderProcedure
   // Add Routes here - do not delete this line
 )

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -51,7 +51,8 @@
     "vaul-vue": "^0.4.1",
     "vue": "catalog:",
     "vue-router": "^4.2.5",
-    "vue-sonner": "^1.3.0"
+    "vue-sonner": "^1.3.0",
+    "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
     "@codeanker/eslint-config": "workspace:*",

--- a/apps/frontend/src/views/FAQs/FAQFormModal.vue
+++ b/apps/frontend/src/views/FAQs/FAQFormModal.vue
@@ -79,6 +79,13 @@ async function onSubmit() {
   emit('success')
 }
 
+async function onDelete() {
+  if (!props.faq) return
+  await apiClient.faq.delete.mutate(props.faq.id)
+  modal.value?.hide()
+  emit('success')
+}
+
 defineExpose<ModalApi>({
   show() {
     modal.value?.show()
@@ -127,7 +134,16 @@ defineExpose<ModalApi>({
               />
             </div>
 
-            <div class="flex justify-end col-span-2 mt-8">
+            <div class="flex justify-between col-span-2 mt-8">
+              <Button
+                v-if="isEdit"
+                type="button"
+                color="danger"
+                @click="onDelete"
+              >
+                Entfernen
+              </Button>
+              <span v-else />
               <Button type="submit"> Speichern </Button>
             </div>
           </ValidateForm>

--- a/apps/frontend/src/views/FAQs/FAQList.vue
+++ b/apps/frontend/src/views/FAQs/FAQList.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { apiClient } from '@/api'
 import Loading from '@/components/UIComponents/Loading.vue'
+import { Bars3Icon } from '@heroicons/vue/24/outline'
 import { useAsyncState } from '@vueuse/core'
-import { computed, ref, useTemplateRef } from 'vue'
+import { computed, ref, useTemplateRef, watch } from 'vue'
+import draggable from 'vuedraggable'
 import FAQFormModal, { type FAQ } from './FAQFormModal.vue'
+import { toast } from 'vue-sonner'
 
 type Props = {
   unterveranstaltungId: string
@@ -11,17 +14,47 @@ type Props = {
 
 const { unterveranstaltungId } = defineProps<Props>()
 
-const { state, isLoading, execute } = useAsyncState(() => apiClient.faq.list.query({ unterveranstaltungId }), {})
-const hasKeys = computed(() => Object.keys(state.value).length > 0)
+const { state, isLoading, execute } = useAsyncState(
+  async () => apiClient.faq.list.query({ unterveranstaltungId }),
+  {},
+  { resetOnExecute: false }
+)
+
+type Category = {
+  name: string
+  categoryId: string
+  faqs: FAQ[]
+}
+const categories = ref<Category[]>([])
+watch(state, () => {
+  categories.value = Object.entries(state.value).map(([name, faqs]) => ({
+    name,
+    categoryId: faqs[0]?.categoryId ?? '',
+    faqs: [...faqs],
+  }))
+})
+
+const hasKeys = computed(() => categories.value.length > 0)
 
 const formModal = useTemplateRef('formModal')
 const editFaq = ref<FAQ>()
 
 function openFormModal(faq?: FAQ) {
-  if (faq !== undefined) {
-    editFaq.value = faq
-  }
+  editFaq.value = faq
   formModal.value?.show()
+}
+
+async function saveOrder() {
+  const faqOrder = categories.value.flatMap((cat) =>
+    cat.faqs.map((faq, index) => ({ id: faq.id, sortOrder: index, categoryId: cat.categoryId }))
+  )
+  const categoryOrder = categories.value.map((cat, index) => ({
+    id: cat.categoryId,
+    sortOrder: index,
+  }))
+  await apiClient.faq.reorder.mutate({ faqOrder, categoryOrder })
+  await execute()
+  toast.success('FAQ-Reihenfolge gespeichert')
 }
 
 defineExpose({
@@ -37,27 +70,50 @@ defineExpose({
     @success="execute"
   />
 
-  <Loading v-if="isLoading" />
+  <Loading v-if="isLoading && !hasKeys" />
   <p v-else-if="!hasKeys">Hier wurden noch keine FAQs angelegt.</p>
 
-  <div
-    v-for="(list, category) in state"
+  <draggable
     v-else
-    :key="category"
-    class="space-y-4"
+    v-model="categories"
+    item-key="categoryId"
+    handle=".category-handle"
+    class="grid grid-cols-3 gap-8 items-start"
+    @end="saveOrder"
   >
-    <p class="text-gray-500 font-normal">{{ category }}</p>
-    <div
-      v-for="(faq, index) in list"
-      :key="index"
-      class="transition-all rounded-lg shadow hover:shadow-lg bg-primary-5 dark:bg-primary-950 p-2 select-none cursor-pointer"
-      @click="() => openFormModal(faq)"
-    >
-      <span class="font-bold">{{ faq.question }}</span>
-      <br />
-      <!-- eslint-disable vue/no-v-html -->
-      <div v-html="faq.answer" />
-      <!-- eslint-enable vue/no-v-html -->
-    </div>
-  </div>
+    <template #item="{ element: category }">
+      <div class="space-y-4 mb-6">
+        <div class="flex items-center gap-2">
+          <Bars3Icon class="category-handle w-5 h-5 text-gray-400 cursor-grab active:cursor-grabbing" />
+          <p class="text-gray-500 font-normal">{{ category.name }}</p>
+        </div>
+        <draggable
+          v-model="category.faqs"
+          item-key="id"
+          handle=".faq-handle"
+          group="faqs"
+          class="space-y-4"
+          @end="saveOrder"
+        >
+          <template #item="{ element: faq }">
+            <div
+              class="transition-all rounded-lg shadow hover:shadow-lg bg-primary-5 dark:bg-primary-950 p-2 select-none flex items-start gap-2"
+            >
+              <Bars3Icon class="faq-handle w-5 h-5 mt-0.5 text-gray-400 cursor-grab active:cursor-grabbing shrink-0" />
+              <div
+                class="cursor-pointer flex-1"
+                @click="() => openFormModal(faq)"
+              >
+                <span class="font-bold">{{ faq.question }}</span>
+                <br />
+                <!-- eslint-disable vue/no-v-html -->
+                <div v-html="faq.answer" />
+                <!-- eslint-enable vue/no-v-html -->
+              </div>
+            </div>
+          </template>
+        </draggable>
+      </div>
+    </template>
+  </draggable>
 </template>

--- a/apps/frontend/src/views/FAQs/FAQList.vue
+++ b/apps/frontend/src/views/FAQs/FAQList.vue
@@ -46,11 +46,11 @@ function openFormModal(faq?: FAQ) {
 
 async function saveOrder() {
   const faqOrder = categories.value.flatMap((cat) =>
-    cat.faqs.map((faq, index) => ({ id: faq.id, sortOrder: index, categoryId: cat.categoryId }))
+    cat.faqs.map((faq, index) => ({ id: faq.id, order: index, categoryId: cat.categoryId }))
   )
   const categoryOrder = categories.value.map((cat, index) => ({
     id: cat.categoryId,
-    sortOrder: index,
+    order: index,
   }))
   await apiClient.faq.reorder.mutate({ faqOrder, categoryOrder })
   await execute()

--- a/apps/frontend/src/views/Unterveranstaltung/UnterveranstaltungDetail.vue
+++ b/apps/frontend/src/views/Unterveranstaltung/UnterveranstaltungDetail.vue
@@ -374,16 +374,16 @@ const anmeldeLinkCreateModal = useTemplateRef('anmeldeLinkCreateModal')
             </p>
           </div>
           <div class="flex items-center gap-x-4">
-          <RouterLink
+            <RouterLink
               class="text-primary-600 flex items-center gap-x-1"
-            :to="{
-              name: 'Unterveranstaltung Custom Field erstellen',
-              params: { veranstaltungId: route.params.veranstaltungId },
-            }"
-          >
+              :to="{
+                name: 'Unterveranstaltung Custom Field erstellen',
+                params: { veranstaltungId: route.params.veranstaltungId },
+              }"
+            >
               <PlusIcon class="size-4" />
               <span>Neues Feld</span>
-          </RouterLink>
+            </RouterLink>
             <RouterLink
               class="text-primary-600 flex items-center gap-x-1"
               :to="{
@@ -416,13 +416,11 @@ const anmeldeLinkCreateModal = useTemplateRef('anmeldeLinkCreateModal')
           <div class="flex-1"></div>
           <Button @click="() => faqList?.openFormModal()"> Frage anlegen </Button>
         </div>
-        <div class="grid grid-cols-3 gap-8">
-          <FAQList
-            v-if="unterveranstaltung"
-            ref="faqList"
-            :unterveranstaltung-id="unterveranstaltung.id"
-          />
-        </div>
+        <FAQList
+          v-if="unterveranstaltung"
+          ref="faqList"
+          :unterveranstaltung-id="unterveranstaltung.id"
+        />
         <hr class="my-10" />
       </Tab>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,6 +373,9 @@ importers:
       vue-sonner:
         specifier: ^1.3.0
         version: 1.3.2
+      vuedraggable:
+        specifier: ^4.1.0
+        version: 4.1.0(vue@3.5.13(typescript@5.7.2))
     devDependencies:
       '@codeanker/eslint-config':
         specifier: workspace:*
@@ -5209,6 +5212,11 @@ packages:
       typescript:
         optional: true
 
+  vuedraggable@4.1.0:
+    resolution: {integrity: sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==}
+    peerDependencies:
+      vue: ^3.0.1
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -9608,8 +9616,7 @@ snapshots:
 
   slick@1.12.2: {}
 
-  sortablejs@1.14.0:
-    optional: true
+  sortablejs@1.14.0: {}
 
   source-map-js@1.2.1: {}
 
@@ -10159,6 +10166,11 @@ snapshots:
       '@vue/shared': 3.5.13
     optionalDependencies:
       typescript: 5.7.2
+
+  vuedraggable@4.1.0(vue@3.5.13(typescript@5.7.2)):
+    dependencies:
+      sortablejs: 1.14.0
+      vue: 3.5.13(typescript@5.7.2)
 
   w3c-keyname@2.2.8: {}
 


### PR DESCRIPTION
Erlaubt dem Gliederungs-Admin die FAQs zu sortieren und zu löschen.
Und löst ein Bug, wo das erstellen nach bearbeiten eines FAQs erst nach neuladen der Seite möglich war.

https://github.com/user-attachments/assets/817e5671-f5ca-4660-8904-225a710b990b

solves #473
solves #474 
solves #475 